### PR TITLE
Assess speed up due to heap data structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ coverage: coverage.out
 
 .PHONY: performance
 performance:
-	cd ./tests && echo MAPPED GRAPH && QUIET=1 GRAPH_TYPE=MAPPED go run .
-	cd ./tests && echo HEAPED GRAPH && QUIET=1 GRAPH_TYPE=HEAPED go run .
+	cd ./tests && echo MAPPED GRAPH && QUIET=$${QUIET-1} GRAPH_TYPE=MAPPED go run .
+	cd ./tests && echo HEAPED GRAPH && QUIET=$${QUIET-1} GRAPH_TYPE=HEAPED go run .
 
 bench: .bench.log
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ coverage: coverage.out
 
 .PHONY: performance
 performance:
-	cd ./tests && go run .
+	cd ./tests && echo MAPPED GRAPH && QUIET=1 GRAPH_TYPE=MAPPED go run .
+	cd ./tests && echo HEAPED GRAPH && QUIET=1 GRAPH_TYPE=HEAPED go run .
 
 bench: .bench.log
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,20 @@ performance:
 	cd ./tests && echo MAPPED GRAPH && QUIET=$${QUIET-1} GRAPH_TYPE=MAPPED go run .
 	cd ./tests && echo HEAPED GRAPH && QUIET=$${QUIET-1} GRAPH_TYPE=HEAPED go run .
 
+.PHONY: readme_test
+readme_test:
+	# Ensure the example in the readme actually works. Do this by extracting the
+	# quoted code from the readme using awk into a temporary directory, then
+	# initialise a temporary go module there, then run the example.
+	repodir=$$(pwd) && \
+	tmpdir=$$(mktemp -d) && \
+	awk 'BEGIN{printme=false}{if($$1 == "```"){printme=0};if(printme){print};if($$1 == "```go"){printme=1};}' README.md > $$tmpdir/main.go && \
+	cd $$tmpdir && go mod init main  && \
+	echo "replace github.com/razziel89/astar => $${repodir}" >> go.mod && \
+	go mod tidy && \
+	go run main.go && \
+	rm -r $$tmpdir
+
 bench: .bench.log
 
 .bench.log: go.* *.go

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 default: lint
 
 build: astar
@@ -12,7 +14,9 @@ lint:
 test: .test.log
 
 .test.log: go.* *.go
-	go test ./... | tee .test.log
+	set -o pipefail && \
+		go test ./... | tee .test.log || \
+		rm .test.log
 
 coverage.out: go.* *.go
 	go test -coverprofile=coverage.out 
@@ -25,3 +29,10 @@ coverage: coverage.out
 .PHONY: performance
 performance:
 	cd ./tests && go run .
+
+bench: .bench.log
+
+.bench.log: go.* *.go
+	set -o pipefail && \
+		go test -bench=. ./... | tee .bench.log || \
+		rm .bench.log

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,7 @@ coverage.out: go.* *.go
 .PHONY: coverage
 coverage: coverage.out
 	xdg-open coverage.html
+
+.PHONY: performance
+performance:
+	cd ./tests && go run .

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ func main() {
 	// neighbours, 2 in x direction and 2 in y direction. This value
 	// just improves performances during allocation.
 	neighbours := 4
-	// This is the graph we will be using to find the path.
-	graph := astar.NewGraph()
+	// This is the graph we will be using to find the path. Provide the
+    // estimated number of nodes for improved performance.
+	graph := astar.NewGraph(gridSize * gridSize)
 	// We remember the node for each position. This makes creating
 	// connections easier.
 	posToNode := map[[2]int]*astar.Node{}

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ func main() {
 	// the biggest headache. But this algorithm permits arbitrary
 	// connections, even one-directional ones.
 	path, err := astar.FindPath(
-		graph, start, end, heuristic.Heuristic(0),
+		&graph, start, end, heuristic.Heuristic(0),
 	)
 	// Error handling.
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ func main() {
 	// just improves performances during allocation.
 	neighbours := 4
 	// This is the graph we will be using to find the path.
-	graph := astar.Graph{}
+	graph := astar.NewGraph()
 	// We remember the node for each position. This makes creating
 	// connections easier.
 	posToNode := map[[2]int]*astar.Node{}
@@ -133,7 +133,7 @@ func main() {
 	// the biggest headache. But this algorithm permits arbitrary
 	// connections, even one-directional ones.
 	path, err := astar.FindPath(
-		&graph, start, end, heuristic.Heuristic(0),
+		graph, start, end, heuristic.Heuristic(0),
 	)
 	// Error handling.
 	if err != nil {

--- a/astar.go
+++ b/astar.go
@@ -113,9 +113,9 @@ func ExtractPath(end, start *Node, orgOrder bool) ([]*Node, error) {
 func FindReversePath(open, closed *Graph, end *Node, heuristic Heuristic) error {
 	for len(*open) != 0 && !closed.Has(end) {
 		// Find the next cheapest node from the open list. This removes it as well as return it.
-		nextCheckNode := open.PopCheapest(heuristic)
+		nextCheckNode := open.PopCheapest()
 		// Add this node to the closed list.
-		closed.Add(nextCheckNode)
+		closed.Push(nextCheckNode, heuristic(nextCheckNode))
 		// Process each of the neighbours.
 		for neigh := range nextCheckNode.connections {
 			// If a neighbour is already on the closed list, skip it. Don't modify it at all.
@@ -134,7 +134,7 @@ func FindReversePath(open, closed *Graph, end *Node, heuristic Heuristic) error 
 					return fmt.Errorf("node %s already has a predecessor", neigh.ToString())
 				}
 				// Add the new, as yet unknown node to the open list.
-				open.Add(neigh)
+				open.Push(neigh, heuristic(neigh))
 				neigh.prev = nextCheckNode
 				neigh.trackedCost = nextCheckNode.trackedCost + neigh.Cost
 			}

--- a/astar.go
+++ b/astar.go
@@ -92,8 +92,8 @@ func FindPath(graph GraphOps, start, end *Node, heuristic Heuristic) (path []*No
 	var open, closed, resetGraph GraphOps
 	switch graph.(type) {
 	case *Graph:
-		open = NewGraph()
-		closed = NewGraph()
+		open = NewGraph(1)
+		closed = NewGraph(1)
 		resetGraph = nil
 	case *HeapedGraph:
 		open = NewHeapedGraph(1)

--- a/astar.go
+++ b/astar.go
@@ -27,13 +27,33 @@ import (
 var (
 	extractPath     = ExtractPath
 	findReversePath = FindReversePath
-	resetFn         = nodeResetFn
+	resetFnGetter   = getNodeResetFn
 )
 
-func nodeResetFn(node *Node) error {
-	node.prev = nil
-	node.trackedCost = defaultCost
-	return nil
+func getNodeResetFn(resetGraph GraphOps) func(*Node) error {
+	return func(node *Node) error {
+		node.prev = nil
+		node.trackedCost = defaultCost
+		node.graph = resetGraph
+		return nil
+	}
+}
+
+func getPanicHandler(err *error) func() {
+	return func() {
+		if recovered := recover(); recovered != nil {
+			// Something panicked. Determine whether we did. If not, propagate the panic.
+			if panickedErr, wasError := recovered.(error); wasError {
+				// We panicked. Propagate the error, but don't overwrite existing errors.
+				if err != nil && *err == nil {
+					*err = panickedErr
+				}
+			} else {
+				// We didn't panic. Propagate the panic.
+				panic(recovered)
+			}
+		}
+	}
 }
 
 // FindPath finds the path between the start and end node. It is a convenience wrapper around
@@ -43,8 +63,8 @@ func nodeResetFn(node *Node) error {
 // the path at the end.
 //
 // This function requires you to provide one of the graph types from this package as the `graph`
-// argument. If you want to use your own implementation of a GraphOps, you will need to use
-// FindReversePath instead. Use NewGraph or NewHeapedGraph to obtain a suitable data structure.
+// argument. Use NewGraph or NewHeapedGraph to obtain a suitable data structure. If you want to use
+// your own implementation of a GraphOps, you will need to use FindReversePath instead.
 //
 // This implementation modifies the original nodes during execution! In the end, the nodes are
 // reverted to null states (private members set to the appropriate zero values), which allows you to
@@ -53,7 +73,11 @@ func nodeResetFn(node *Node) error {
 // FindPath also takes a heuristic that estimates the cost for moving from a node to the end. In the
 // easiest case, this can be built using ConstantHeuristic. This heuristic is evaluated exactly once
 // for a node when adding that node to an internal graph.
-func FindPath(graph GraphOps, start *Node, end *Node, heuristic Heuristic) ([]*Node, error) {
+//
+// This function is guaranteed to handle panics from this package and not to propagate the panic.
+func FindPath(graph GraphOps, start, end *Node, heuristic Heuristic) (path []*Node, err error) {
+	// Handle panics internally.
+	defer getPanicHandler(&err)()
 
 	// Sanity checks
 	if !graph.Has(start) {
@@ -65,27 +89,28 @@ func FindPath(graph GraphOps, start *Node, end *Node, heuristic Heuristic) ([]*N
 
 	// Open and closed lists will be of the same type as the input graph. To support that, we assert
 	// the type here and initialise appropriately.
-	var open, closed GraphOps
+	var open, closed, resetGraph GraphOps
 	switch graph.(type) {
 	case *Graph:
 		open = NewGraph()
 		closed = NewGraph()
+		resetGraph = nil
 	case *HeapedGraph:
 		open = NewHeapedGraph(1)
 		closed = NewHeapedGraph(1)
+		resetGraph = graph
 	default:
 		err := fmt.Errorf(
 			"unknown input GraphOps type, if you provided your own, use FindReversePath directly",
 		)
 		return []*Node{}, err
 	}
-
 	// Variable open is our open list containing all nodes that should still be checked. At the
 	// beginning, this is only the start node.
 	// The closed list is empty at the beginning.
 	open.Push(start, graphVal)
 
-	err := findReversePath(open, closed, end, heuristic)
+	err = findReversePath(open, closed, end, heuristic)
 	if err != nil {
 		return []*Node{}, fmt.Errorf("error during path finding: %s", err.Error())
 	}
@@ -95,14 +120,15 @@ func FindPath(graph GraphOps, start *Node, end *Node, heuristic Heuristic) ([]*N
 		return []*Node{}, err
 	}
 	// Extract a path from end to start in the order from start to end.
-	path, err := extractPath(end, start, true)
+	path, err = extractPath(end, start, true)
 	if err != nil {
 		return []*Node{}, fmt.Errorf("internal error during path extraction: %s", err.Error())
 	}
 
 	// Set the prev pointer back to nil. That way, the input graph can be used again. Also set the
-	// tracked cost back to zero.
-	err = graph.Apply(resetFn)
+	// tracked cost back to zero. Also set the graph member back to the original graph if that one
+	// was a heaped graph.
+	err = graph.Apply(resetFnGetter(resetGraph))
 	if err != nil {
 		return []*Node{}, fmt.Errorf("internal error during node reset: %s", err.Error())
 	}
@@ -139,6 +165,8 @@ func ExtractPath(end, start *Node, orgOrder bool) ([]*Node, error) {
 // FindReversePath finds a reverse path from the start node to the end node. Follow the prev member
 // of the end node to traverse the path backwards. To use this function, in the beginning, the open
 // list must contain the start node and the closed list must be empty.
+//
+// This function may panic. If you want panics to be handled internally, use FindPath instead.
 func FindReversePath(open, closed GraphOps, end *Node, heuristic Heuristic) error {
 	for open.Len() != 0 && !closed.Has(end) {
 		// Find the next cheapest node from the open list. This removes it as well as return it.
@@ -153,19 +181,15 @@ func FindReversePath(open, closed GraphOps, end *Node, heuristic Heuristic) erro
 			}
 			if open.Has(neigh) {
 				// Update the node in case we found a better path to it.
-				newCost := nextCheckNode.trackedCost + neigh.Cost
-				if newCost < neigh.trackedCost {
-					neigh.prev = nextCheckNode
-					neigh.trackedCost = newCost
-				}
+				open.UpdateIfBetter(neigh, nextCheckNode, nextCheckNode.trackedCost)
 			} else {
 				if neigh.prev != nil {
 					return fmt.Errorf("node %s already has a predecessor", neigh.ToString())
 				}
 				// Add the new, as yet unknown node to the open list.
-				open.Push(neigh, heuristic(neigh))
 				neigh.prev = nextCheckNode
 				neigh.trackedCost = nextCheckNode.trackedCost + neigh.Cost
+				open.Push(neigh, heuristic(neigh))
 			}
 		}
 	}

--- a/astar.go
+++ b/astar.go
@@ -30,6 +30,16 @@ var (
 	resetFnGetter   = getNodeResetFn
 )
 
+// Error is the error type that can be returned by the astar package. It is used to determine
+// which errors occurred inside the package and which ones occurred outside of it.
+type Error struct {
+	message string
+}
+
+func (e Error) Error() string {
+	return e.message
+}
+
 func getNodeResetFn(resetGraph GraphOps) func(*Node) error {
 	return func(node *Node) error {
 		node.prev = nil
@@ -43,7 +53,7 @@ func getPanicHandler(err *error) func() {
 	return func() {
 		if recovered := recover(); recovered != nil {
 			// Something panicked. Determine whether we did. If not, propagate the panic.
-			if panickedErr, wasError := recovered.(error); wasError {
+			if panickedErr, wasError := recovered.(Error); wasError {
 				// We panicked. Propagate the error, but don't overwrite existing errors.
 				if err != nil && *err == nil {
 					*err = panickedErr

--- a/astar_custom_ops_test.go
+++ b/astar_custom_ops_test.go
@@ -1,0 +1,59 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A custom graph ops implementation used for testing of errors due to custom graph ops.
+type mockGraphOps struct{}
+
+func (mo *mockGraphOps) Len() int {
+	return 0
+}
+func (mo *mockGraphOps) Has(_ *Node) bool {
+	return true // Simulate to contain all nodes.
+}
+func (mo *mockGraphOps) Add(_ *Node)         {}
+func (mo *mockGraphOps) Push(_ *Node, _ int) {}
+func (mo *mockGraphOps) Remove(*Node)        {}
+func (mo *mockGraphOps) PopCheapest() *Node {
+	return nil
+}
+func (mo *mockGraphOps) Apply(func(*Node) error) error {
+	return nil
+}
+func (mo *mockGraphOps) UpdateIfBetter(*Node, *Node, int) {}
+
+func TestFindPathFailureCustomGraphOps(t *testing.T) {
+
+	mockStart, _ := NewNode("start", 0, 0, nil)
+	mockEnd, _ := NewNode("end", 0, 0, nil)
+
+	mockStart.AddPairwiseConnection(mockEnd)
+
+	graph := mockGraphOps{}
+	graph.Add(mockStart)
+	graph.Add(mockEnd)
+
+	_, err := FindPath(&graph, mockStart, mockEnd, mockHeuristic)
+	assert.Error(t, err)
+}

--- a/astar_functional_test.go
+++ b/astar_functional_test.go
@@ -93,7 +93,7 @@ func TestBasicConnectionStraightLine(t *testing.T) {
 	}
 	nodeMap, err := nodeListToMap(nodes)
 	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err := FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[1], nodes[2]}
 	assertPathsEqual(t, expectedPath, path)
@@ -141,7 +141,7 @@ func TestBasicConnectionStraightLineWithEndingBranches(t *testing.T) {
 	}
 	nodeMap, err := nodeListToMap(nodes)
 	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err := FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[4], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)
@@ -213,7 +213,7 @@ func TestBasicConnectionSquareEqualCost(t *testing.T) {
 	}
 	nodeMap, err := nodeListToMap(nodes)
 	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err := FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[1], nodes[4], nodes[7], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)
@@ -285,7 +285,7 @@ func TestBasicConnectionSquareVaryingCost(t *testing.T) {
 	}
 	nodeMap, err := nodeListToMap(nodes)
 	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err := FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)
@@ -359,7 +359,7 @@ func TestOneWayConnection(t *testing.T) {
 	}
 	nodeMap, err := nodeListToMap(nodes)
 	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err := FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)
@@ -368,7 +368,7 @@ func TestOneWayConnection(t *testing.T) {
 	// that the connection from nodes[8] to nodes[7] added above is not taken, since it is only one
 	// way.
 	nodes[7].AddConnection(nodes[8])
-	path, err = FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+	path, err = FindPath(&nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath = []*Node{nodes[0], nodes[3], nodes[4], nodes[7], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)

--- a/astar_functional_test.go
+++ b/astar_functional_test.go
@@ -380,19 +380,31 @@ func TestOneWayConnection(t *testing.T) {
 			init.AddConnection(con)
 		}
 	}
-	nodeMap, err := nodeListToGraph(nodes, "default")
-	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
-	assert.NoError(t, err)
-	expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
-	assertPathsEqual(t, expectedPath, path)
+	for _, graphType := range []string{"default", "heaped"} {
+		t.Logf("Running for %s", graphType)
+		nodeMap, err := nodeListToGraph(nodes, graphType)
+		assert.NoError(t, err)
+		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+		assert.NoError(t, err)
+		expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
+		assertPathsEqual(t, expectedPath, path)
 
-	// As soon as the one additional connection is added, the better path is found. This ensures
-	// that the connection from nodes[8] to nodes[7] added above is not taken, since it is only one
-	// way.
-	nodes[7].AddConnection(nodes[8])
-	path, err = FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
-	assert.NoError(t, err)
-	expectedPath = []*Node{nodes[0], nodes[3], nodes[4], nodes[7], nodes[8]}
-	assertPathsEqual(t, expectedPath, path)
+		t.Logf("Logging for %s", graphType)
+		for _, node := range nodes {
+			t.Log(node)
+		}
+
+		t.Logf("Running updated for %s", graphType)
+		// As soon as the one additional connection is added, the better path is found. This ensures
+		// that the connection from nodes[8] to nodes[7] added above is not taken, since it is only
+		// one way.
+		nodes[7].AddConnection(nodes[8])
+		path, err = FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+		assert.NoError(t, err)
+		expectedPath = []*Node{nodes[0], nodes[3], nodes[4], nodes[7], nodes[8]}
+		assertPathsEqual(t, expectedPath, path)
+
+		// Remove the connection again to make tests independent.
+		nodes[7].RemoveConnection(nodes[8])
+	}
 }

--- a/astar_functional_test.go
+++ b/astar_functional_test.go
@@ -151,12 +151,14 @@ func TestBasicConnectionStraightLineWithEndingBranches(t *testing.T) {
 			init.AddPairwiseConnection(con)
 		}
 	}
-	nodeMap, err := nodeListToGraph(nodes, "default")
-	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
-	assert.NoError(t, err)
-	expectedPath := []*Node{nodes[0], nodes[4], nodes[8]}
-	assertPathsEqual(t, expectedPath, path)
+	for _, graphType := range []string{"default", "heaped"} {
+		nodeMap, err := nodeListToGraph(nodes, graphType)
+		assert.NoError(t, err)
+		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+		assert.NoError(t, err)
+		expectedPath := []*Node{nodes[0], nodes[4], nodes[8]}
+		assertPathsEqual(t, expectedPath, path)
+	}
 }
 
 //nolint:funlen
@@ -223,12 +225,14 @@ func TestBasicConnectionSquareEqualCost(t *testing.T) {
 			init.AddPairwiseConnection(con)
 		}
 	}
-	nodeMap, err := nodeListToGraph(nodes, "default")
-	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
-	assert.NoError(t, err)
-	expectedPath := []*Node{nodes[0], nodes[1], nodes[4], nodes[7], nodes[8]}
-	assertPathsEqual(t, expectedPath, path)
+	for _, graphType := range []string{"default", "heaped"} {
+		nodeMap, err := nodeListToGraph(nodes, graphType)
+		assert.NoError(t, err)
+		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+		assert.NoError(t, err)
+		expectedPath := []*Node{nodes[0], nodes[1], nodes[4], nodes[7], nodes[8]}
+		assertPathsEqual(t, expectedPath, path)
+	}
 }
 
 //nolint:funlen
@@ -295,12 +299,15 @@ func TestBasicConnectionSquareVaryingCost(t *testing.T) {
 			init.AddPairwiseConnection(con)
 		}
 	}
+	// This test fails for the heaped graph.
+	// for _, graphType := range []string{"default", "heaped"} {
 	nodeMap, err := nodeListToGraph(nodes, "default")
 	assert.NoError(t, err)
 	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
 	assert.NoError(t, err)
 	expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
 	assertPathsEqual(t, expectedPath, path)
+	// }
 }
 
 //nolint:funlen

--- a/astar_functional_test.go
+++ b/astar_functional_test.go
@@ -102,6 +102,7 @@ func TestBasicConnectionStraightLine(t *testing.T) {
 		}
 	}
 	for _, graphType := range []string{"default", "heaped"} {
+		t.Logf("Running for %s", graphType)
 		nodeMap, err := nodeListToGraph(nodes, graphType)
 		assert.NoError(t, err)
 		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
@@ -152,6 +153,7 @@ func TestBasicConnectionStraightLineWithEndingBranches(t *testing.T) {
 		}
 	}
 	for _, graphType := range []string{"default", "heaped"} {
+		t.Logf("Running for %s", graphType)
 		nodeMap, err := nodeListToGraph(nodes, graphType)
 		assert.NoError(t, err)
 		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
@@ -226,6 +228,7 @@ func TestBasicConnectionSquareEqualCost(t *testing.T) {
 		}
 	}
 	for _, graphType := range []string{"default", "heaped"} {
+		t.Logf("Running for %s", graphType)
 		nodeMap, err := nodeListToGraph(nodes, graphType)
 		assert.NoError(t, err)
 		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
@@ -300,14 +303,15 @@ func TestBasicConnectionSquareVaryingCost(t *testing.T) {
 		}
 	}
 	// This test fails for the heaped graph.
-	// for _, graphType := range []string{"default", "heaped"} {
-	nodeMap, err := nodeListToGraph(nodes, "default")
-	assert.NoError(t, err)
-	path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
-	assert.NoError(t, err)
-	expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
-	assertPathsEqual(t, expectedPath, path)
-	// }
+	for _, graphType := range []string{"default", "heaped"} {
+		t.Logf("Running for %s", graphType)
+		nodeMap, err := nodeListToGraph(nodes, graphType)
+		assert.NoError(t, err)
+		path, err := FindPath(nodeMap, nodes[0], nodes[len(nodes)-1], heuristic.Heuristic(0))
+		assert.NoError(t, err)
+		expectedPath := []*Node{nodes[0], nodes[3], nodes[4], nodes[5], nodes[8]}
+		assertPathsEqual(t, expectedPath, path)
+	}
 }
 
 //nolint:funlen

--- a/astar_test.go
+++ b/astar_test.go
@@ -32,7 +32,7 @@ var errMock = fmt.Errorf("some error")
 
 // Set up test cases for find path. The two functions used by it will return the provided error
 // values.
-func setUpFindPath(errFindReverse, errExtract error, connect bool) func() {
+func setUpFindPath(errFindReverse, errExtract, errCleanUp error, connect bool) func() {
 
 	node1, _ := NewNode("start", 0, 0, nil)
 	node2, _ := NewNode("end", 0, 0, nil)
@@ -57,14 +57,19 @@ func setUpFindPath(errFindReverse, errExtract error, connect bool) func() {
 		return mockPath, errExtract
 	}
 
-	findReversePath = func(_, _ *Graph, _ *Node, _ Heuristic) error {
+	findReversePath = func(_, _ GraphOps, _ *Node, _ Heuristic) error {
 		return errFindReverse
+	}
+
+	resetFn = func(_ *Node) error {
+		return errCleanUp
 	}
 
 	return func() {
 		// Revert changes.
 		extractPath = ExtractPath
 		findReversePath = FindReversePath
+
 		mockPath = []*Node{}
 		mockGraph = Graph{}
 		mockStart = nil
@@ -73,10 +78,10 @@ func setUpFindPath(errFindReverse, errExtract error, connect bool) func() {
 }
 
 func TestFindPathSuccess(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
-	path, err := FindPath(mockGraph, mockStart, mockEnd, mockHeuristic)
+	path, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(path))
@@ -85,49 +90,49 @@ func TestFindPathSuccess(t *testing.T) {
 }
 
 func TestFindPathFailurePathExtraction(t *testing.T) {
-	tearDown := setUpFindPath(errMock, nil, true)
+	tearDown := setUpFindPath(errMock, nil, nil, true)
 	defer tearDown()
 
-	_, err := FindPath(mockGraph, mockStart, mockEnd, mockHeuristic)
+	_, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestFindPathFailurePathFinding(t *testing.T) {
-	tearDown := setUpFindPath(nil, errMock, true)
+	tearDown := setUpFindPath(nil, errMock, nil, true)
 	defer tearDown()
 
-	_, err := FindPath(mockGraph, mockStart, mockEnd, mockHeuristic)
+	_, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestFindPathFailureNoEnd(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
-	_, err := FindPath(mockGraph, mockStart, nil, mockHeuristic)
+	_, err := FindPath(&mockGraph, mockStart, nil, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestFindPathFailureNoStart(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
-	_, err := FindPath(mockGraph, nil, mockEnd, mockHeuristic)
+	_, err := FindPath(&mockGraph, nil, mockEnd, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestFindPathFailureAlreadyConnection(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
 	findReversePath = FindReversePath
 
-	_, err := FindPath(mockGraph, mockStart, mockEnd, mockHeuristic)
+	_, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestFindPathFailureNoConnectionToEnd(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, false)
+	tearDown := setUpFindPath(nil, nil, nil, false)
 	defer tearDown()
 
 	mockEnd.RemoveConnection(mockStart)
@@ -135,12 +140,12 @@ func TestFindPathFailureNoConnectionToEnd(t *testing.T) {
 
 	findReversePath = FindReversePath
 
-	_, err := FindPath(mockGraph, mockStart, mockEnd, mockHeuristic)
+	_, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
 	assert.Error(t, err)
 }
 
 func TestExtractPathSuccessNoReverse(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
 	path, err := ExtractPath(mockEnd, mockStart, false)
@@ -152,7 +157,7 @@ func TestExtractPathSuccessNoReverse(t *testing.T) {
 }
 
 func TestExtractPathSuccessReverse(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
 	path, err := ExtractPath(mockEnd, mockStart, true)
@@ -164,7 +169,7 @@ func TestExtractPathSuccessReverse(t *testing.T) {
 }
 
 func TestExtractPathFailureNoConnection(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, false)
+	tearDown := setUpFindPath(nil, nil, nil, false)
 	defer tearDown()
 
 	_, err := ExtractPath(mockEnd, mockStart, true)
@@ -172,7 +177,7 @@ func TestExtractPathFailureNoConnection(t *testing.T) {
 }
 
 func TestFindPathBetterConnection(t *testing.T) {
-	tearDown := setUpFindPath(nil, nil, true)
+	tearDown := setUpFindPath(nil, nil, nil, true)
 	defer tearDown()
 
 	mockMid, _ := NewNode("mid", 0, 0, nil)
@@ -192,4 +197,12 @@ func TestFindPathBetterConnection(t *testing.T) {
 	)
 
 	assert.NoError(t, err)
+}
+
+func TestFindPathFailureNodeReset(t *testing.T) {
+	tearDown := setUpFindPath(nil, nil, errMock, true)
+	defer tearDown()
+
+	_, err := FindPath(&mockGraph, mockStart, mockEnd, mockHeuristic)
+	assert.Error(t, err)
 }

--- a/astar_test.go
+++ b/astar_test.go
@@ -61,8 +61,10 @@ func setUpFindPath(errFindReverse, errExtract, errCleanUp error, connect bool) f
 		return errFindReverse
 	}
 
-	resetFn = func(_ *Node) error {
-		return errCleanUp
+	resetFnGetter = func(_ GraphOps) func(_ *Node) error {
+		return func(_ *Node) error {
+			return errCleanUp
+		}
 	}
 
 	return func() {

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/graph.go
+++ b/graph.go
@@ -45,8 +45,14 @@ type GraphOps interface {
 
 // Graph is a collection of nodes. Note that there are no guarantees for the nodes to be connected.
 // Ensuring that is the user's task. Each nodes is assigned to its estimate. That means a node's
-// estimate will never be able to change once added.
+// estimate will never be able to change once added. Get a graph via NewGraph.
 type Graph map[*Node]int
+
+// NewGraph obtains a new graph. No arguments are required. This function returns a normal graph
+// based on a Go map. That structure has sub-optimal performance but works.
+func NewGraph() GraphOps {
+	return &Graph{}
+}
 
 // This is the default value for the graph. Specifying it once here simplifies the code.
 var graphVal = 0

--- a/graph.go
+++ b/graph.go
@@ -57,7 +57,10 @@ func (g *Graph) PopCheapest(heuristic Heuristic) *Node {
 	cost := 0
 	var result *Node
 	for node := range *g {
-		estimatedCost := heuristic(node)
+		var estimatedCost int
+		if heuristic != nil {
+			estimatedCost = heuristic(node)
+		}
 		if !found || node.trackedCost+estimatedCost < cost {
 			found = true
 			result = node

--- a/graph.go
+++ b/graph.go
@@ -22,6 +22,27 @@ import (
 	"sort"
 )
 
+// GraphOps is an interface needed for a graph to be usable with the path finding functions in this
+// module. See the method documentation of the actual Graph type for what the individual methods do
+// in detail.
+type GraphOps interface {
+	// Len specifies how many elements there are in the graph.
+	Len() int
+	// Has checks whether a node is in the graph.
+	Has(node *Node) bool
+	// Add adds a node to a graph without an estimate.
+	Add(node *Node)
+	// Push adds a node to a graph with an estimate.
+	Push(node *Node, estimate int)
+	// Remove removes a specific node from a graph.
+	Remove(node *Node)
+	// PopCheapest retrieves and removes the cheapest node from the graph. Cost is equal to the
+	// node's cost added to its estimate.
+	PopCheapest() *Node
+	// Apply applies a function to all nodes in the graph. That function may error out.
+	Apply(func(*Node) error) error
+}
+
 // Graph is a collection of nodes. Note that there are no guarantees for the nodes to be connected.
 // Ensuring that is the user's task. Each nodes is assigned to its estimate. That means a node's
 // estimate will never be able to change once added.
@@ -33,6 +54,11 @@ var graphVal = 0
 // GraphVal is a convenience wrapper to return the default graph value.
 func GraphVal() int {
 	return graphVal
+}
+
+// Len determines the number of elements.
+func (g *Graph) Len() int {
+	return len(*g)
 }
 
 // Has determines whether a graph contains a specific node.
@@ -71,6 +97,17 @@ func (g *Graph) PopCheapest() *Node {
 	}
 	g.Remove(result)
 	return result
+}
+
+// Apply apples a function to all nodes in the graph.
+func (g *Graph) Apply(fn func(*Node) error) error {
+	for node := range *g {
+		err := fn(node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ToString provides a string representation of the graph. The nodes are sorted according to their

--- a/graph.go
+++ b/graph.go
@@ -41,6 +41,10 @@ type GraphOps interface {
 	PopCheapest() *Node
 	// Apply applies a function to all nodes in the graph. That function may error out.
 	Apply(func(*Node) error) error
+	// UpdateIfBetter updates a node's best connection if that is cheaper than any previously found
+	// one. It takes the node to update, the new possible best predecessor and the cost for reaching
+	// that predecessor.
+	UpdateIfBetter(*Node, *Node, int)
 }
 
 // Graph is a collection of nodes. Note that there are no guarantees for the nodes to be connected.
@@ -105,7 +109,7 @@ func (g *Graph) PopCheapest() *Node {
 	return result
 }
 
-// Apply apples a function to all nodes in the graph.
+// Apply applies a function to all nodes in the graph.
 func (g *Graph) Apply(fn func(*Node) error) error {
 	for node := range *g {
 		err := fn(node)
@@ -114,6 +118,20 @@ func (g *Graph) Apply(fn func(*Node) error) error {
 		}
 	}
 	return nil
+}
+
+// UpdateIfBetter updates a node's best connection if that is cheaper than any previously found one.
+// It takes the node to update, the new possible best predecessor and the cost for reaching that
+// predecessor.
+func (g *Graph) UpdateIfBetter(node, prev *Node, newCost int) {
+	if !g.Has(node) {
+		panic(fmt.Errorf("cannot update node outside this graph"))
+	}
+	newCost += node.Cost
+	if newCost < node.trackedCost {
+		node.prev = prev
+		node.trackedCost = newCost
+	}
 }
 
 // ToString provides a string representation of the graph. The nodes are sorted according to their

--- a/graph.go
+++ b/graph.go
@@ -53,9 +53,11 @@ type GraphOps interface {
 type Graph map[*Node]int
 
 // NewGraph obtains a new graph. No arguments are required. This function returns a normal graph
-// based on a Go map. That structure has sub-optimal performance but works.
-func NewGraph() GraphOps {
-	return &Graph{}
+// based on a Go map. That structure has sub-optimal performance but works. Specify the estimated
+// number of nodes as argument to boost performance. See Graph for details.
+func NewGraph(estimatedSize int) GraphOps {
+	self := make(Graph, estimatedSize)
+	return &self
 }
 
 // This is the default value for the graph. Specifying it once here simplifies the code.

--- a/graph.go
+++ b/graph.go
@@ -127,7 +127,7 @@ func (g *Graph) Apply(fn func(*Node) error) error {
 // predecessor.
 func (g *Graph) UpdateIfBetter(node, prev *Node, newCost int) {
 	if !g.Has(node) {
-		panic(fmt.Errorf("cannot update node outside this graph"))
+		panic(Error{"cannot update node outside this graph"})
 	}
 	newCost += node.Cost
 	if newCost < node.trackedCost {

--- a/graph_test.go
+++ b/graph_test.go
@@ -31,6 +31,12 @@ func mockHeuristic(node *Node) int {
 	return node.Cost + 1
 }
 
+func TestNewGraph(t *testing.T) {
+	_ = NewGraph(100).(*Graph)
+	// We cannot check the capacity of a map in Go. Thus, this check is somewhat incomplete.
+	// assert.Equal(t, 100, cap(*graph))
+}
+
 func TestGraphAddRemoveSuccess(t *testing.T) {
 	node, err := NewNode("node", 0, 0, nil)
 	assert.NoError(t, err)

--- a/graph_test.go
+++ b/graph_test.go
@@ -59,6 +59,53 @@ func TestGraphHas(t *testing.T) {
 	assert.True(t, graph.Has(node))
 }
 
+func TestGraphApplySuccess(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	graph := Graph{}
+	graph.Add(node)
+
+	mockApplyFn := func(node *Node) error {
+		node.prev = node
+		return nil
+	}
+
+	assert.Nil(t, node.prev)
+	err = graph.Apply(mockApplyFn)
+	assert.NoError(t, err)
+	assert.Equal(t, node, node.prev)
+}
+
+func TestGraphApplyFail(t *testing.T) {
+	node1, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	node2, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	graph := Graph{}
+	graph.Add(node1)
+	graph.Add(node2)
+
+	mockApplyFn := func(node *Node) error {
+		node.prev = node
+		return errMock
+	}
+
+	assert.Nil(t, node1.prev)
+	assert.Nil(t, node2.prev)
+	err = graph.Apply(mockApplyFn)
+	assert.Error(t, err)
+	// Ensure the apply fn has not been applied to all nodes but only until an error happened.
+	nilCount := 0
+	for node := range graph {
+		if node.prev == nil {
+			nilCount++
+		}
+	}
+	assert.Equal(t, 1, nilCount)
+}
+
 func TestGraphPopCheapest(t *testing.T) {
 	graph := Graph{}
 	var expectedCheapest *Node

--- a/graph_test.go
+++ b/graph_test.go
@@ -177,7 +177,7 @@ func TestGraphUpdateIfBetterFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	defer func() {
-		err, wasError := recover().(error)
+		err, wasError := recover().(Error)
 		assert.True(t, wasError)
 		assert.Error(t, err)
 	}()

--- a/graph_test.go
+++ b/graph_test.go
@@ -62,8 +62,9 @@ func TestGraphHas(t *testing.T) {
 func TestGraphPopCheapest(t *testing.T) {
 	graph := Graph{}
 	var expectedCheapest *Node
-	for _, cost := range []int{1, 2, 0, 3} {
-		node, err := NewNode("node", cost, 0, nil)
+	for idx, cost := range []int{1, 2, 0, 3} {
+		node, err := NewNode(fmt.Sprintf("node%d", idx), cost, 0, nil)
+		node.trackedCost = node.Cost
 		assert.NoError(t, err)
 		graph.Add(node)
 		if cost == 0 {
@@ -71,6 +72,22 @@ func TestGraphPopCheapest(t *testing.T) {
 		}
 	}
 	cheapest := graph.PopCheapest(mockHeuristic)
+	assert.Equal(t, expectedCheapest, cheapest)
+}
+
+func TestGraphPopCheapestNoHeuristic(t *testing.T) {
+	graph := Graph{}
+	var expectedCheapest *Node
+	for idx, cost := range []int{1, 2, 0, 3} {
+		node, err := NewNode(fmt.Sprintf("node%d", idx), cost, 0, nil)
+		node.trackedCost = node.Cost
+		assert.NoError(t, err)
+		graph.Add(node)
+		if cost == 0 {
+			expectedCheapest = node
+		}
+	}
+	cheapest := graph.PopCheapest(nil)
 	assert.Equal(t, expectedCheapest, cheapest)
 }
 

--- a/graph_test.go
+++ b/graph_test.go
@@ -151,3 +151,36 @@ func TestGraphVal(t *testing.T) {
 	graph.Add(node)
 	assert.Equal(t, GraphVal(), graph[node])
 }
+
+func TestGraphUpdateIfBetterSuccess(t *testing.T) {
+	graph := Graph{}
+
+	node1, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph.Add(node1)
+	node2, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph.Add(node2)
+
+	node2.AddPairwiseConnection(node1)
+	node2.trackedCost = 0
+	assert.Nil(t, node2.prev)
+
+	graph.UpdateIfBetter(node2, node1, -10)
+	assert.Equal(t, node1, node2.prev)
+}
+
+func TestGraphUpdateIfBetterFailure(t *testing.T) {
+	graph := Graph{}
+
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	defer func() {
+		err, wasError := recover().(error)
+		assert.True(t, wasError)
+		assert.Error(t, err)
+	}()
+
+	graph.UpdateIfBetter(node, nil, 0)
+}

--- a/graph_test.go
+++ b/graph_test.go
@@ -71,23 +71,7 @@ func TestGraphPopCheapest(t *testing.T) {
 			expectedCheapest = node
 		}
 	}
-	cheapest := graph.PopCheapest(mockHeuristic)
-	assert.Equal(t, expectedCheapest, cheapest)
-}
-
-func TestGraphPopCheapestNoHeuristic(t *testing.T) {
-	graph := Graph{}
-	var expectedCheapest *Node
-	for idx, cost := range []int{1, 2, 0, 3} {
-		node, err := NewNode(fmt.Sprintf("node%d", idx), cost, 0, nil)
-		node.trackedCost = node.Cost
-		assert.NoError(t, err)
-		graph.Add(node)
-		if cost == 0 {
-			expectedCheapest = node
-		}
-	}
-	cheapest := graph.PopCheapest(nil)
+	cheapest := graph.PopCheapest()
 	assert.Equal(t, expectedCheapest, cheapest)
 }
 

--- a/heap.go
+++ b/heap.go
@@ -1,0 +1,129 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Heap is a collection of nodes on a minimum heap. Note that there are no guarantees for the nodes
+// to be connected. Ensuring that is the user's task.
+type Heap []*Node
+
+// Len provides the length of the heap. This is needed for Go's heap interface.
+func (h *Heap) Len() int {
+	return len(*h)
+}
+
+// Less determines whether one value is smaller than another one. This is needed for Go's heap
+// interface.
+func (h *Heap) Less(i, j int) bool {
+	return (*h)[i].trackedCost < (*h)[j].trackedCost
+}
+
+// Swap swaps two values in the heap. This is needed for Go's heap interface.
+func (h *Heap) Swap(i, j int) {
+	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
+}
+
+// Push adds a value to the heap. This is needed for Go's heap interface. Don't use it directly, use
+// Add to add nodes. This one will panic if you provide an incorrect type thanks to Go's lack of
+// generics.
+func (h *Heap) Push(x interface{}) {
+	*h = append(*h, x.(*Node))
+}
+
+// Pop removes a value from the heap. This is needed for Go's heap interface.
+func (h *Heap) Pop() interface{} {
+	if len(*h) == 0 {
+		return nil
+	}
+	length := len(*h)
+	last := (*h)[length-1]
+	if len(*h) > 1 {
+		*h = (*h)[0 : length-2]
+	} else {
+		*h = Heap{}
+	}
+	return last
+}
+
+// Has determines whether a heap contains a specific node. This is inefficient for a heap as we need
+// to operate over much of the underlying slice.
+func (h *Heap) Has(findNode *Node) bool {
+	for _, node := range *h {
+		if node == findNode {
+			return true
+		}
+	}
+	return false
+}
+
+// Add adds a node to the heap. If the node already exists, this a no-op. Note that repeated calls
+// to this are inefficient for the heap since they query Has. Use Push if you are sure the node does
+// not yet exist.
+func (h *Heap) Add(node *Node) {
+	if !h.Has(node) {
+		h.Push(node)
+	}
+}
+
+// Remove removes a node from the heap. If the node does not exist, this a no-op. Note that repeated
+// calls to this are inefficient for the heap as they will have to iterate over the entire data
+// structure. Even when removing a value, all data after the removed datum will be copied.
+func (h *Heap) Remove(findNode *Node) {
+	for idx, node := range *h {
+		if node == findNode {
+			*h = append((*h)[0:idx], (*h)[idx+1:]...)
+			return
+		}
+	}
+}
+
+// PopCheapest retrieves one of the cheapest nodes and removes it. This will return nil if the heap
+// is empty.
+func (h *Heap) PopCheapest() *Node {
+	if len(*h) > 0 {
+		return h.Pop().(*Node)
+	}
+	return nil
+}
+
+// ToString provides a string representation of the heap. The nodes are sorted according to their
+// user-defined names. If you provide a heuristic != nil, the value that heuristic provides for each
+// node is also provided at the end of a line. Provide nil to disable.
+func (h *Heap) ToString(heuristic Heuristic) string {
+	nodes := append([]*Node{}, (*h)...)
+
+	lessFn := func(idx1, idx2 int) bool {
+		return nodes[idx1].ID < nodes[idx2].ID
+	}
+	sort.SliceStable(nodes, lessFn)
+	str := ""
+	for idx, node := range nodes {
+		str += node.ToString()
+		if heuristic != nil {
+			str += fmt.Sprintf(" -> %d", heuristic(node))
+		}
+		if idx != len(nodes)-1 {
+			str += "\n"
+		}
+	}
+	return str
+}

--- a/heap.go
+++ b/heap.go
@@ -56,11 +56,7 @@ func (h *Heap) Pop() interface{} {
 	}
 	length := len(*h)
 	last := (*h)[length-1]
-	if len(*h) > 1 {
-		*h = (*h)[0 : length-2]
-	} else {
-		*h = Heap{}
-	}
+	*h = (*h)[0 : length-1]
 	return last
 }
 
@@ -99,7 +95,10 @@ func (h *Heap) Remove(findNode *Node) {
 // PopCheapest retrieves one of the cheapest nodes and removes it. This will return nil if the heap
 // is empty.
 func (h *Heap) PopCheapest() *Node {
-	return h.Pop().(*Node)
+	if val, ok := h.Pop().(*Node); ok {
+		return val
+	}
+	return nil
 }
 
 // ToString provides a string representation of the heap. The nodes are sorted according to their

--- a/heap.go
+++ b/heap.go
@@ -22,8 +22,8 @@ import (
 	"sort"
 )
 
-// Heap is a collection of nodes on a minimum heap. Note that there are no guarantees for the nodes
-// to be connected. Ensuring that is the user's task.
+// Heap is a collection of nodes on a minimum heap. It implements Go's heap.Interface. It is used by
+// the heapable graph to store the actual nodes. Don't use this data structre on its own.
 type Heap []*Node
 
 // Len provides the length of the heap. This is needed for Go's heap interface.

--- a/heap.go
+++ b/heap.go
@@ -22,9 +22,15 @@ import (
 	"sort"
 )
 
+// HeapElement is an element of a heap.
+type HeapElement struct {
+	Node     *Node
+	Estimate int
+}
+
 // Heap is a collection of nodes on a minimum heap. It implements Go's heap.Interface. It is used by
 // the heapable graph to store the actual nodes. Don't use this data structre on its own.
-type Heap []*Node
+type Heap []HeapElement
 
 // Len provides the length of the heap. This is needed for Go's heap interface.
 func (h *Heap) Len() int {
@@ -34,7 +40,7 @@ func (h *Heap) Len() int {
 // Less determines whether one value is smaller than another one. This is needed for Go's heap
 // interface.
 func (h *Heap) Less(i, j int) bool {
-	return (*h)[i].trackedCost < (*h)[j].trackedCost
+	return (*h)[i].Node.trackedCost < (*h)[j].Node.trackedCost
 }
 
 // Swap swaps two values in the heap. This is needed for Go's heap interface.
@@ -46,7 +52,7 @@ func (h *Heap) Swap(i, j int) {
 // Add to add nodes. This one will panic if you provide an incorrect type thanks to Go's lack of
 // generics.
 func (h *Heap) Push(x interface{}) {
-	*h = append(*h, x.(*Node))
+	*h = append(*h, x.(HeapElement))
 }
 
 // Pop removes a value from the heap. This is needed for Go's heap interface.
@@ -60,52 +66,14 @@ func (h *Heap) Pop() interface{} {
 	return last
 }
 
-// Has determines whether a heap contains a specific node. This is inefficient for a heap as we need
-// to operate over much of the underlying slice.
-func (h *Heap) Has(findNode *Node) bool {
-	for _, node := range *h {
-		if node == findNode {
-			return true
-		}
-	}
-	return false
-}
-
-// Add adds a node to the heap. If the node already exists, this a no-op. Note that repeated calls
-// to this are inefficient for the heap since they query Has. Use Push if you are sure the node does
-// not yet exist.
-func (h *Heap) Add(node *Node) {
-	if !h.Has(node) {
-		h.Push(node)
-	}
-}
-
-// Remove removes a node from the heap. If the node does not exist, this a no-op. Note that repeated
-// calls to this are inefficient for the heap as they will have to iterate over the entire data
-// structure. Even when removing a value, all data after the removed datum will be copied.
-func (h *Heap) Remove(findNode *Node) {
-	for idx, node := range *h {
-		if node == findNode {
-			*h = append((*h)[0:idx], (*h)[idx+1:]...)
-			return
-		}
-	}
-}
-
-// PopCheapest retrieves one of the cheapest nodes and removes it. This will return nil if the heap
-// is empty.
-func (h *Heap) PopCheapest() *Node {
-	if val, ok := h.Pop().(*Node); ok {
-		return val
-	}
-	return nil
-}
-
 // ToString provides a string representation of the heap. The nodes are sorted according to their
 // user-defined names. If you provide a heuristic != nil, the value that heuristic provides for each
 // node is also provided at the end of a line. Provide nil to disable.
 func (h *Heap) ToString(heuristic Heuristic) string {
-	nodes := append([]*Node{}, (*h)...)
+	nodes := make([]*Node, 0, len(*h))
+	for _, nodeElem := range *h {
+		nodes = append(nodes, nodeElem.Node)
+	}
 
 	lessFn := func(idx1, idx2 int) bool {
 		return nodes[idx1].ID < nodes[idx2].ID

--- a/heap.go
+++ b/heap.go
@@ -99,10 +99,7 @@ func (h *Heap) Remove(findNode *Node) {
 // PopCheapest retrieves one of the cheapest nodes and removes it. This will return nil if the heap
 // is empty.
 func (h *Heap) PopCheapest() *Node {
-	if len(*h) > 0 {
-		return h.Pop().(*Node)
-	}
-	return nil
+	return h.Pop().(*Node)
 }
 
 // ToString provides a string representation of the heap. The nodes are sorted according to their

--- a/heap.go
+++ b/heap.go
@@ -40,7 +40,9 @@ func (h *Heap) Len() int {
 // Less determines whether one value is smaller than another one. This is needed for Go's heap
 // interface.
 func (h *Heap) Less(i, j int) bool {
-	return (*h)[i].Node.trackedCost < (*h)[j].Node.trackedCost
+	iElem := (*h)[i]
+	jElem := (*h)[j]
+	return iElem.Node.trackedCost+iElem.Estimate < jElem.Node.trackedCost+jElem.Estimate
 }
 
 // Swap swaps two values in the heap. This is needed for Go's heap interface.

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func BenchmarkGraphAdd10KNodes(b *testing.B) {
-	graph := Graph{}
+	graph := NewGraph(tenK)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", tenK-j, 0, nil)
@@ -38,7 +38,7 @@ func BenchmarkGraphAdd10KNodes(b *testing.B) {
 }
 
 func BenchmarkGraphAdd100KNodes(b *testing.B) {
-	graph := Graph{}
+	graph := NewGraph(hundredK)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", hundredK-j, 0, nil)
@@ -90,7 +90,7 @@ func BenchmarkHeapedGraphAdd100KNodes(b *testing.B) {
 }
 
 func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
-	graph := Graph{}
+	graph := NewGraph(tenK)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", tenK-j, 0, nil)
@@ -103,7 +103,7 @@ func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
 }
 
 func BenchmarkGraphPopCheapest100KNodes(b *testing.B) {
-	graph := Graph{}
+	graph := NewGraph(hundredK)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", hundredK-j, 0, nil)

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -82,7 +82,7 @@ func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
 			graph.Add(node)
 		}
 		for j := 0; j < tenK; j++ {
-			_ = graph.PopCheapest(nil)
+			_ = graph.PopCheapest()
 		}
 	}
 }
@@ -95,7 +95,7 @@ func BenchmarkGraphPopCheapest100KNodes(b *testing.B) {
 			graph.Add(node)
 		}
 		for j := 0; j < hundredK; j++ {
-			_ = graph.PopCheapest(nil)
+			_ = graph.PopCheapest()
 		}
 	}
 }

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -69,16 +69,6 @@ func BenchmarkHeapPush100KNodes(b *testing.B) {
 	}
 }
 
-func BenchmarkHeapAdd10KNodes(b *testing.B) {
-	heap := Heap{}
-	for i := 0; i < b.N; i++ {
-		for j := 0; j < tenK; j++ {
-			node, _ := NewNode("", tenK-j, 0, nil)
-			heap.Add(node)
-		}
-	}
-}
-
 func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
 	graph := Graph{}
 	for i := 0; i < b.N; i++ {

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -53,7 +53,7 @@ func BenchmarkHeapPush10KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", tenK-j, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
 		}
 	}
 }
@@ -64,7 +64,27 @@ func BenchmarkHeapPush100KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", hundredK-j, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
+		}
+	}
+}
+
+func BenchmarkHeapedGraphAdd10KNodes(b *testing.B) {
+	graph := NewHeapedGraph(tenK)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", tenK-j, 0, nil)
+			graph.Add(node)
+		}
+	}
+}
+
+func BenchmarkHeapedGraphAdd100KNodes(b *testing.B) {
+	graph := NewHeapedGraph(hundredK)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", hundredK-j, 0, nil)
+			graph.Add(node)
 		}
 	}
 }
@@ -101,7 +121,7 @@ func BenchmarkHeapPop10KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
 		}
 		for j := 0; j < tenK; j++ {
 			_ = goheap.Pop(&heap)
@@ -115,7 +135,7 @@ func BenchmarkHeapPop100KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
 		}
 		for j := 0; j < hundredK; j++ {
 			_ = goheap.Pop(&heap)
@@ -129,7 +149,7 @@ func BenchmarkHeapPopCheapest10KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
 		}
 		for j := 0; j < tenK; j++ {
 			_ = goheap.Pop(&heap)
@@ -143,10 +163,36 @@ func BenchmarkHeapPopCheapest100KNodes(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			goheap.Push(&heap, node)
+			goheap.Push(&heap, HeapElement{node, 0})
 		}
 		for j := 0; j < hundredK; j++ {
 			_ = goheap.Pop(&heap)
+		}
+	}
+}
+
+func BenchmarkHeapedGraphPopCheapest10KNodes(b *testing.B) {
+	graph := NewHeapedGraph(tenK)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", tenK-j, 0, nil)
+			graph.Add(node)
+		}
+		for j := 0; j < tenK; j++ {
+			_ = graph.PopCheapest()
+		}
+	}
+}
+
+func BenchmarkHeapedGraphPopCheapest100KNodes(b *testing.B) {
+	graph := NewHeapedGraph(hundredK)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", hundredK-j, 0, nil)
+			graph.Add(node)
+		}
+		for j := 0; j < hundredK; j++ {
+			_ = graph.PopCheapest()
 		}
 	}
 }

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -1,0 +1,93 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import "testing"
+
+const (
+	tenK = 1000
+)
+
+func BenchmarkGraphAdd10KNodes(b *testing.B) {
+	graph := Graph{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			graph.Add(node)
+		}
+	}
+}
+
+func BenchmarkHeapPush10KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Push(node)
+		}
+	}
+}
+
+func BenchmarkHeapAdd10KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Add(node)
+		}
+	}
+}
+
+func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
+	graph := Graph{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			graph.Add(node)
+		}
+		for j := 0; j < tenK; j++ {
+			_ = graph.PopCheapest(nil)
+		}
+	}
+}
+
+func BenchmarkHeapPop10KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Push(node)
+		}
+		for j := 0; j < tenK; j++ {
+			_ = heap.Pop()
+		}
+	}
+}
+
+func BenchmarkHeapPopCheapest10KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < tenK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Push(node)
+		}
+		for j := 0; j < tenK; j++ {
+			_ = heap.PopCheapest()
+		}
+	}
+}

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -17,7 +17,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 package astar
 
-import "testing"
+import (
+	goheap "container/heap"
+	"testing"
+)
 
 const (
 	tenK     = 1000
@@ -46,20 +49,22 @@ func BenchmarkGraphAdd100KNodes(b *testing.B) {
 
 func BenchmarkHeapPush10KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", tenK-j, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 	}
 }
 
 func BenchmarkHeapPush100KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", hundredK-j, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 	}
 }
@@ -102,52 +107,56 @@ func BenchmarkGraphPopCheapest100KNodes(b *testing.B) {
 
 func BenchmarkHeapPop10KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 		for j := 0; j < tenK; j++ {
-			_ = heap.Pop()
+			_ = goheap.Pop(&heap)
 		}
 	}
 }
 
 func BenchmarkHeapPop100KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 		for j := 0; j < hundredK; j++ {
-			_ = heap.Pop()
+			_ = goheap.Pop(&heap)
 		}
 	}
 }
 
 func BenchmarkHeapPopCheapest10KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 		for j := 0; j < tenK; j++ {
-			_ = heap.PopCheapest()
+			_ = goheap.Pop(&heap)
 		}
 	}
 }
 
 func BenchmarkHeapPopCheapest100KNodes(b *testing.B) {
 	heap := Heap{}
+	goheap.Init(&heap)
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < hundredK; j++ {
 			node, _ := NewNode("", 0, 0, nil)
-			heap.Push(node)
+			goheap.Push(&heap, node)
 		}
 		for j := 0; j < hundredK; j++ {
-			_ = heap.PopCheapest()
+			_ = goheap.Pop(&heap)
 		}
 	}
 }

--- a/heap_bench_test.go
+++ b/heap_bench_test.go
@@ -20,14 +20,25 @@ package astar
 import "testing"
 
 const (
-	tenK = 1000
+	tenK     = 1000
+	hundredK = 10000
 )
 
 func BenchmarkGraphAdd10KNodes(b *testing.B) {
 	graph := Graph{}
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
-			node, _ := NewNode("", 0, 0, nil)
+			node, _ := NewNode("", tenK-j, 0, nil)
+			graph.Add(node)
+		}
+	}
+}
+
+func BenchmarkGraphAdd100KNodes(b *testing.B) {
+	graph := Graph{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", hundredK-j, 0, nil)
 			graph.Add(node)
 		}
 	}
@@ -37,7 +48,17 @@ func BenchmarkHeapPush10KNodes(b *testing.B) {
 	heap := Heap{}
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
-			node, _ := NewNode("", 0, 0, nil)
+			node, _ := NewNode("", tenK-j, 0, nil)
+			heap.Push(node)
+		}
+	}
+}
+
+func BenchmarkHeapPush100KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", hundredK-j, 0, nil)
 			heap.Push(node)
 		}
 	}
@@ -47,7 +68,7 @@ func BenchmarkHeapAdd10KNodes(b *testing.B) {
 	heap := Heap{}
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
-			node, _ := NewNode("", 0, 0, nil)
+			node, _ := NewNode("", tenK-j, 0, nil)
 			heap.Add(node)
 		}
 	}
@@ -57,10 +78,23 @@ func BenchmarkGraphPopCheapest10KNodes(b *testing.B) {
 	graph := Graph{}
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < tenK; j++ {
-			node, _ := NewNode("", 0, 0, nil)
+			node, _ := NewNode("", tenK-j, 0, nil)
 			graph.Add(node)
 		}
 		for j := 0; j < tenK; j++ {
+			_ = graph.PopCheapest(nil)
+		}
+	}
+}
+
+func BenchmarkGraphPopCheapest100KNodes(b *testing.B) {
+	graph := Graph{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", hundredK-j, 0, nil)
+			graph.Add(node)
+		}
+		for j := 0; j < hundredK; j++ {
 			_ = graph.PopCheapest(nil)
 		}
 	}
@@ -79,6 +113,19 @@ func BenchmarkHeapPop10KNodes(b *testing.B) {
 	}
 }
 
+func BenchmarkHeapPop100KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Push(node)
+		}
+		for j := 0; j < hundredK; j++ {
+			_ = heap.Pop()
+		}
+	}
+}
+
 func BenchmarkHeapPopCheapest10KNodes(b *testing.B) {
 	heap := Heap{}
 	for i := 0; i < b.N; i++ {
@@ -87,6 +134,19 @@ func BenchmarkHeapPopCheapest10KNodes(b *testing.B) {
 			heap.Push(node)
 		}
 		for j := 0; j < tenK; j++ {
+			_ = heap.PopCheapest()
+		}
+	}
+}
+
+func BenchmarkHeapPopCheapest100KNodes(b *testing.B) {
+	heap := Heap{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < hundredK; j++ {
+			node, _ := NewNode("", 0, 0, nil)
+			heap.Push(node)
+		}
+		for j := 0; j < hundredK; j++ {
 			_ = heap.PopCheapest()
 		}
 	}

--- a/heap_test.go
+++ b/heap_test.go
@@ -30,43 +30,27 @@ func TestHeapLenPush(t *testing.T) {
 	for idx := 0; idx < 3; idx++ {
 		node, err := NewNode("", 0, 0, nil)
 		assert.NoError(t, err)
-		heap.Push(node)
+		heap.Push(HeapElement{Node: node, Estimate: 0})
 	}
 	assert.Equal(t, 3, heap.Len())
 }
 
-func TestHeapAddRemove(t *testing.T) {
-	heap := Heap{}
-	var expected *Node
-	for idx := 0; idx < 3; idx++ {
-		node, err := NewNode("", 0, 0, nil)
-		if expected == nil {
-			expected = node
-		}
-		assert.NoError(t, err)
-		heap.Add(node)
-	}
-	assert.Equal(t, 3, heap.Len())
-	heap.Remove(expected)
-	assert.Equal(t, 2, heap.Len())
-}
-
-func TestHeapPopHas(t *testing.T) {
+func TestHeapPop(t *testing.T) {
 	heap := Heap{}
 	goheap.Init(&heap)
 	var expected *Node
 	for _, cost := range []int{5, 2, 4, 6, 0, 4, 6, 2} {
 		node, err := NewNode(fmt.Sprint(cost), cost, 0, nil)
 		node.trackedCost = cost
-		if expected == nil {
+		if cost == 0 {
 			expected = node
 		}
 		assert.NoError(t, err)
-		goheap.Push(&heap, node)
+		goheap.Push(&heap, HeapElement{Node: node, Estimate: 0})
 	}
-	assert.True(t, heap.Has(expected))
-	popped := goheap.Pop(&heap).(*Node)
-	assert.Equal(t, 0, popped.Cost)
+	popped := goheap.Pop(&heap).(HeapElement)
+	assert.Equal(t, 0, popped.Node.Cost)
+	assert.Equal(t, expected, popped.Node)
 }
 
 func TestHeapPushPopAndPopCheapest(t *testing.T) {
@@ -80,16 +64,15 @@ func TestHeapPushPopAndPopCheapest(t *testing.T) {
 			expected = node
 		}
 		assert.NoError(t, err)
-		goheap.Push(&heap, node)
+		goheap.Push(&heap, HeapElement{Node: node, Estimate: 0})
 	}
-	popped := goheap.Pop(&heap).(*Node)
+	popped := goheap.Pop(&heap).(HeapElement)
 	assert.NotNil(t, popped)
-	popped = goheap.Pop(&heap).(*Node)
+	popped = goheap.Pop(&heap).(HeapElement)
 	assert.NotNil(t, popped)
-	popped = heap.PopCheapest()
+	popped = goheap.Pop(&heap).(HeapElement)
 	assert.NotNil(t, popped)
-	popped = heap.PopCheapest()
-	assert.Nil(t, popped)
+	assert.Zero(t, heap.Len())
 }
 
 func TestHeapToString(t *testing.T) {
@@ -103,7 +86,7 @@ func TestHeapToString(t *testing.T) {
 			expected = node
 		}
 		assert.NoError(t, err)
-		goheap.Push(&heap, node)
+		goheap.Push(&heap, HeapElement{Node: node, Estimate: 0})
 	}
 	expectedString := "{id: node2, cost: 2, con: ['']} -> 3\n" +
 		"{id: node4, cost: 4, con: ['']} -> 5\n" +

--- a/heap_test.go
+++ b/heap_test.go
@@ -53,6 +53,11 @@ func TestHeapPop(t *testing.T) {
 	assert.Equal(t, expected, popped.Node)
 }
 
+func TestHeapPopEmpty(t *testing.T) {
+	heap := Heap{}
+	assert.Nil(t, heap.Pop())
+}
+
 func TestHeapPushPopAndPopCheapest(t *testing.T) {
 	heap := Heap{}
 	goheap.Init(&heap)

--- a/heap_test.go
+++ b/heap_test.go
@@ -35,12 +35,47 @@ func TestHeapLenPush(t *testing.T) {
 	assert.Equal(t, 3, heap.Len())
 }
 
-func TestHeapPop(t *testing.T) {
+func TestHeapAddRemove(t *testing.T) {
+	heap := Heap{}
+	var expected *Node
+	for idx := 0; idx < 3; idx++ {
+		node, err := NewNode("", 0, 0, nil)
+		if expected == nil {
+			expected = node
+		}
+		assert.NoError(t, err)
+		heap.Add(node)
+	}
+	assert.Equal(t, 3, heap.Len())
+	heap.Remove(expected)
+	assert.Equal(t, 2, heap.Len())
+}
+
+func TestHeapPopHas(t *testing.T) {
 	heap := Heap{}
 	goheap.Init(&heap)
 	var expected *Node
-	for idx := 0; idx < 3; idx++ {
-		node, err := NewNode(fmt.Sprint(idx), idx, 0, nil)
+	for _, cost := range []int{5, 2, 4, 6, 0, 4, 6, 2} {
+		node, err := NewNode(fmt.Sprint(cost), cost, 0, nil)
+		node.trackedCost = cost
+		if expected == nil {
+			expected = node
+		}
+		assert.NoError(t, err)
+		goheap.Push(&heap, node)
+	}
+	assert.True(t, heap.Has(expected))
+	popped := goheap.Pop(&heap).(*Node)
+	assert.Equal(t, 0, popped.Cost)
+}
+
+func TestHeapPushPopAndPopCheapest(t *testing.T) {
+	heap := Heap{}
+	goheap.Init(&heap)
+	var expected *Node
+	for _, cost := range []int{0, 1, 2} {
+		node, err := NewNode(fmt.Sprint(cost), cost, 0, nil)
+		node.trackedCost = cost
 		if expected == nil {
 			expected = node
 		}
@@ -48,5 +83,30 @@ func TestHeapPop(t *testing.T) {
 		goheap.Push(&heap, node)
 	}
 	popped := goheap.Pop(&heap).(*Node)
-	assert.Equal(t, expected, popped)
+	assert.NotNil(t, popped)
+	popped = goheap.Pop(&heap).(*Node)
+	assert.NotNil(t, popped)
+	popped = heap.PopCheapest()
+	assert.NotNil(t, popped)
+	popped = heap.PopCheapest()
+	assert.Nil(t, popped)
+}
+
+func TestHeapToString(t *testing.T) {
+	heap := Heap{}
+	goheap.Init(&heap)
+	var expected *Node
+	for _, cost := range []int{5, 2, 4} {
+		node, err := NewNode(fmt.Sprintf("node%d", cost), cost, 0, nil)
+		node.trackedCost = cost
+		if expected == nil {
+			expected = node
+		}
+		assert.NoError(t, err)
+		goheap.Push(&heap, node)
+	}
+	expectedString := "{id: node2, cost: 2, con: ['']} -> 3\n" +
+		"{id: node4, cost: 4, con: ['']} -> 5\n" +
+		"{id: node5, cost: 5, con: ['']} -> 6"
+	assert.Equal(t, expectedString, heap.ToString(mockHeuristic))
 }

--- a/heap_test.go
+++ b/heap_test.go
@@ -1,0 +1,52 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import (
+	goheap "container/heap"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeapLenPush(t *testing.T) {
+	heap := Heap{}
+	for idx := 0; idx < 3; idx++ {
+		node, err := NewNode("", 0, 0, nil)
+		assert.NoError(t, err)
+		heap.Push(node)
+	}
+	assert.Equal(t, 3, heap.Len())
+}
+
+func TestHeapPop(t *testing.T) {
+	heap := Heap{}
+	goheap.Init(&heap)
+	var expected *Node
+	for idx := 0; idx < 3; idx++ {
+		node, err := NewNode(fmt.Sprint(idx), idx, 0, nil)
+		if expected == nil {
+			expected = node
+		}
+		assert.NoError(t, err)
+		goheap.Push(&heap, node)
+	}
+	popped := goheap.Pop(&heap).(*Node)
+	assert.Equal(t, expected, popped)
+}

--- a/heaped_graph.go
+++ b/heaped_graph.go
@@ -51,10 +51,15 @@ func (g *HeapedGraph) Has(node *Node) bool {
 	return node.graph == g
 }
 
-// Add adds a node to the graph. If the node already exists, this a no-op.
+// Add adds a node to the graph. If the node already exists, this a no-op. This panics if the node
+// already has a different graph set.
 func (g *HeapedGraph) Add(node *Node) {
 	if !g.Has(node) {
+		if node.graph != nil {
+			panic("different graph already set")
+		}
 		goheap.Push(&g.Heap, node)
+		node.graph = g
 	}
 }
 
@@ -70,6 +75,8 @@ func (g *HeapedGraph) Remove(findNode *Node) {
 	for idx, node := range g.Heap {
 		if node.Node == findNode {
 			g.Heap = append(g.Heap[0:idx], g.Heap[idx+1:]...)
+			g.Heap[idx].Node = nil
+			node.Node.graph = nil
 			return
 		}
 	}
@@ -79,6 +86,7 @@ func (g *HeapedGraph) Remove(findNode *Node) {
 // is empty.
 func (g *HeapedGraph) PopCheapest() *Node {
 	if val, ok := goheap.Pop(&g.Heap).(*Node); ok {
+		val.graph = nil
 		return val
 	}
 	return nil

--- a/heaped_graph.go
+++ b/heaped_graph.go
@@ -1,0 +1,126 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import (
+	"fmt"
+	"sort"
+
+	goheap "container/heap"
+)
+
+// HeapedGraph is a collection of nodes. Note that there are no guarantees for the nodes to be
+// connected. Ensuring that is the user's task. Each nodes is assigned to its estimate. That means a
+// node's estimate will never be able to change once added. Get a heaped graph via NewHeapedGraph.
+// This uses a Heap as storage backend.
+type HeapedGraph struct {
+	Heap Heap
+}
+
+// NewHeapedGraph obtains a new heaped graph. Specify the estimated number of nodes as argument to
+// boost performance.
+func NewHeapedGraph(estimatedSize int) GraphOps {
+	heap := make(Heap, 0, estimatedSize)
+	self := &HeapedGraph{Heap: heap}
+	goheap.Init(&self.Heap)
+	return self
+}
+
+// Len determines the number of elements.
+func (g *HeapedGraph) Len() int {
+	return g.Heap.Len()
+}
+
+// Has determines whether a graph contains a specific node.
+func (g *HeapedGraph) Has(node *Node) bool {
+	return node.graph == g
+}
+
+// Add adds a node to the graph. If the node already exists, this a no-op.
+func (g *HeapedGraph) Add(node *Node) {
+	if !g.Has(node) {
+		goheap.Push(&g.Heap, node)
+	}
+}
+
+// Push adds a node to the graph, including its estimate. If the node already exists, this a no-op.
+func (g *HeapedGraph) Push(node *Node, estimate int) {
+	elem := HeapElement{Node: node, Estimate: estimate}
+	goheap.Push(&g.Heap, elem)
+}
+
+// Remove removes a node from the graph. If the node does not exist, this a no-op. This function is
+// inefficient but not needed for the algorithm in general.t
+func (g *HeapedGraph) Remove(findNode *Node) {
+	for idx, node := range g.Heap {
+		if node.Node == findNode {
+			g.Heap = append(g.Heap[0:idx], g.Heap[idx+1:]...)
+			return
+		}
+	}
+}
+
+// PopCheapest retrieves one of the cheapest nodes and removes it. This will return nil if the graph
+// is empty.
+func (g *HeapedGraph) PopCheapest() *Node {
+	if val, ok := goheap.Pop(&g.Heap).(*Node); ok {
+		return val
+	}
+	return nil
+}
+
+// Apply apples a function to all nodes in the graph.
+func (g *HeapedGraph) Apply(fn func(*Node) error) error {
+	for _, elem := range g.Heap {
+		err := fn(elem.Node)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ToString provides a string representation of the graph. The nodes are sorted according to their
+// user-defined names. If you provide a heuristic != nil, the value that heuristic provides for each
+// node is also provided at the end of a line. Providing nil will use the stored estimates.
+func (g *HeapedGraph) ToString(heuristic Heuristic) string {
+	nodes := make([]*Node, 0, len(g.Heap))
+	estimates := make([]int, 0, len(g.Heap))
+	for _, elem := range g.Heap {
+		nodes = append(nodes, elem.Node)
+		estimates = append(estimates, elem.Estimate)
+	}
+
+	lessFn := func(idx1, idx2 int) bool {
+		return nodes[idx1].ID < nodes[idx2].ID
+	}
+	sort.SliceStable(nodes, lessFn)
+	str := ""
+	for idx, node := range nodes {
+		str += node.ToString()
+		estimate := estimates[idx]
+		if heuristic != nil {
+			estimate = heuristic(node)
+		}
+		str += fmt.Sprintf(" -> %d", estimate)
+		if idx < len(nodes)-1 {
+			str += "\n"
+		}
+	}
+	return str
+}

--- a/heaped_graph.go
+++ b/heaped_graph.go
@@ -56,7 +56,7 @@ func (g *HeapedGraph) Has(node *Node) bool {
 func (g *HeapedGraph) Add(node *Node) {
 	if !g.Has(node) {
 		if node.graph != nil {
-			panic(fmt.Errorf("different graph already set"))
+			panic(Error{"different graph already set"})
 		}
 		elem := HeapElement{Node: node, Estimate: graphVal}
 		goheap.Push(&g.Heap, elem)
@@ -113,7 +113,7 @@ func (g *HeapedGraph) Apply(fn func(*Node) error) error {
 // predecessor.
 func (g *HeapedGraph) UpdateIfBetter(node, prev *Node, newCost int) {
 	if !g.Has(node) {
-		panic(fmt.Errorf("cannot update node outside this graph"))
+		panic(Error{"cannot update node outside this graph"})
 	}
 	newCost += node.Cost
 	if newCost < node.trackedCost {

--- a/heaped_graph_test.go
+++ b/heaped_graph_test.go
@@ -153,7 +153,7 @@ func TestHeapedGraphGraphMemberSetPanic(t *testing.T) {
 	node.graph = otherGraph
 	assert.NotNil(t, node.graph)
 	defer func() {
-		err, wasError := recover().(error)
+		err, wasError := recover().(Error)
 		assert.True(t, wasError)
 		assert.Error(t, err)
 	}()
@@ -200,7 +200,7 @@ func TestHeapedGraphUpdateIfBetterFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	defer func() {
-		err, wasError := recover().(error)
+		err, wasError := recover().(Error)
 		assert.True(t, wasError)
 		assert.Error(t, err)
 	}()

--- a/heaped_graph_test.go
+++ b/heaped_graph_test.go
@@ -174,3 +174,36 @@ func TestHeapedGraphToString(t *testing.T) {
 		"{id: node3, cost: 3, con: ['']} -> 4"
 	assert.Equal(t, expectedStr, str)
 }
+
+func TestHeapedGraphUpdateIfBetterSuccess(t *testing.T) {
+	graph := NewHeapedGraph(0)
+
+	node1, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph.Add(node1)
+	node2, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph.Add(node2)
+
+	node2.AddPairwiseConnection(node1)
+	node2.trackedCost = 0
+	assert.Nil(t, node2.prev)
+
+	graph.UpdateIfBetter(node2, node1, -10)
+	assert.Equal(t, node1, node2.prev)
+}
+
+func TestHeapedGraphUpdateIfBetterFailure(t *testing.T) {
+	graph := NewHeapedGraph(0)
+
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	defer func() {
+		err, wasError := recover().(error)
+		assert.True(t, wasError)
+		assert.Error(t, err)
+	}()
+
+	graph.UpdateIfBetter(node, nil, 0)
+}

--- a/heaped_graph_test.go
+++ b/heaped_graph_test.go
@@ -1,0 +1,176 @@
+/* An implementation of the A* algorithm in plain Golang.
+Copyright (C) 2021  Torsten Sachse
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package astar
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewGraph(t *testing.T) {
+	graph := NewHeapedGraph(100).(*HeapedGraph)
+	assert.Equal(t, 100, cap(graph.Heap))
+}
+
+func TestHeapedGraphAddRemoveSuccess(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph := NewHeapedGraph(0).(*HeapedGraph)
+	assert.Equal(t, 0, len(graph.Heap))
+	graph.Add(node)
+	assert.Equal(t, 1, len(graph.Heap))
+	graph.Remove(node)
+	assert.Equal(t, 0, len(graph.Heap))
+	// Another removal is no problem.
+	graph.Remove(node)
+	assert.Equal(t, 0, len(graph.Heap))
+	// Adding a node twice is no problem.
+	graph.Add(node)
+	assert.Equal(t, 1, len(graph.Heap))
+	graph.Add(node)
+	assert.Equal(t, 1, len(graph.Heap))
+}
+
+func TestHeapedGraphPushPopCheapestNoExist(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph := NewHeapedGraph(0).(*HeapedGraph)
+	assert.Equal(t, 0, len(graph.Heap))
+	graph.Push(node, 1)
+	assert.Equal(t, 1, len(graph.Heap))
+	popped := graph.PopCheapest()
+	assert.Equal(t, 0, len(graph.Heap))
+	assert.Equal(t, node, popped)
+	popped = graph.PopCheapest()
+	assert.Nil(t, popped)
+}
+
+func TestHeapedGraphPopCheapest(t *testing.T) {
+	graph := NewHeapedGraph(0)
+	var expectedCheapest *Node
+	for idx, cost := range []int{1, 2, 0, 3} {
+		node, err := NewNode(fmt.Sprintf("node%d", idx), cost, 0, nil)
+		node.trackedCost = node.Cost
+		assert.NoError(t, err)
+		graph.Add(node)
+		if cost == 0 {
+			expectedCheapest = node
+		}
+	}
+	cheapest := graph.PopCheapest()
+	assert.Equal(t, expectedCheapest, cheapest)
+}
+
+func TestHeapedGraphHas(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph := NewHeapedGraph(0)
+	assert.False(t, graph.Has(node))
+	graph.Add(node)
+	assert.True(t, graph.Has(node))
+}
+
+func TestHeapedGraphApplySuccess(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	graph := NewHeapedGraph(0)
+	graph.Add(node)
+
+	mockApplyFn := func(node *Node) error {
+		node.prev = node
+		return nil
+	}
+
+	assert.Nil(t, node.prev)
+	err = graph.Apply(mockApplyFn)
+	assert.NoError(t, err)
+	assert.Equal(t, node, node.prev)
+}
+
+func TestHeapedGraphApplyFail(t *testing.T) {
+	node1, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	node2, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+
+	graph := NewHeapedGraph(0).(*HeapedGraph)
+	graph.Add(node1)
+	graph.Add(node2)
+
+	mockApplyFn := func(node *Node) error {
+		node.prev = node
+		return errMock
+	}
+
+	assert.Nil(t, node1.prev)
+	assert.Nil(t, node2.prev)
+	err = graph.Apply(mockApplyFn)
+	assert.Error(t, err)
+	// Ensure the apply fn has not been applied to all nodes but only until an error happened.
+	nilCount := 0
+	for _, elem := range graph.Heap {
+		if elem.Node.prev == nil {
+			nilCount++
+		}
+	}
+	assert.Equal(t, 1, nilCount)
+}
+
+func TestHeapedGraphLen(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	graph := NewHeapedGraph(0)
+	assert.Equal(t, 0, graph.Len())
+	graph.Add(node)
+	assert.Equal(t, 1, graph.Len())
+}
+
+func TestHeapedGraphGraphMemberSetPanic(t *testing.T) {
+	node, err := NewNode("node", 0, 0, nil)
+	assert.NoError(t, err)
+	otherGraph := NewHeapedGraph(0)
+	graph := NewHeapedGraph(0)
+
+	assert.Zero(t, graph.Len())
+	node.graph = otherGraph
+	assert.NotNil(t, node.graph)
+	defer func() {
+		err, wasError := recover().(error)
+		assert.True(t, wasError)
+		assert.Error(t, err)
+	}()
+	graph.Add(node)
+}
+
+func TestHeapedGraphToString(t *testing.T) {
+	graph := NewHeapedGraph(0).(*HeapedGraph)
+	for idx, cost := range []int{1, 2, 0, 3} {
+		node, err := NewNode(fmt.Sprintf("node%d", idx), cost, 0, nil)
+		assert.NoError(t, err)
+		graph.Add(node)
+	}
+	str := graph.ToString(mockHeuristic)
+	expectedStr := "{id: node0, cost: 1, con: ['']} -> 2\n" +
+		"{id: node1, cost: 2, con: ['']} -> 3\n" +
+		"{id: node2, cost: 0, con: ['']} -> 1\n" +
+		"{id: node3, cost: 3, con: ['']} -> 4"
+	assert.Equal(t, expectedStr, str)
+}

--- a/heaped_graph_test.go
+++ b/heaped_graph_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewGraph(t *testing.T) {
+func TestNewHeapedGraph(t *testing.T) {
 	graph := NewHeapedGraph(100).(*HeapedGraph)
 	assert.Equal(t, 100, cap(graph.Heap))
 }

--- a/node.go
+++ b/node.go
@@ -47,6 +47,8 @@ type Node struct {
 	trackedCost int
 	// Member prev tracks the previous node on the minimal cost connection.
 	prev *Node
+	// Member heap tracks which graph this node is in.
+	graph GraphOps
 }
 
 // NewNode creates a new node. Provide an id string that describes this node for the user. Also

--- a/node.go
+++ b/node.go
@@ -47,7 +47,8 @@ type Node struct {
 	trackedCost int
 	// Member prev tracks the previous node on the minimal cost connection.
 	prev *Node
-	// Member heap tracks which graph this node is in.
+	// Member graph tracks which graph this node is in. This will be set appripriately by the
+	// algorithm when adding and removing nodes to or from a heaped graph.
 	graph GraphOps
 }
 

--- a/node.go
+++ b/node.go
@@ -48,7 +48,8 @@ type Node struct {
 	// Member prev tracks the previous node on the minimal cost connection.
 	prev *Node
 	// Member graph tracks which graph this node is in. This will be set appripriately by the
-	// algorithm when adding and removing nodes to or from a heaped graph.
+	// algorithm when adding and removing nodes to or from a heaped graph. This member is used only
+	// by the HeapedGraph.
 	graph GraphOps
 }
 
@@ -104,4 +105,9 @@ func (n *Node) ToString() string {
 		"{id: %s, cost: %d, con: ['%s']}",
 		n.ID, n.Cost, conString,
 	)
+}
+
+// String obtains a string representation suitable for use with fmt's Print functions.
+func (n Node) String() string {
+	return n.ToString()
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,7 @@
+module main
+
+go 1.16
+
+replace github.com/razziel89/astar => ../
+
+require github.com/razziel89/astar v0.0.0-00010101000000-000000000000

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/main.go
+++ b/tests/main.go
@@ -1,0 +1,90 @@
+// Package main describes one large tests.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/razziel89/astar"
+)
+
+const (
+	seed     = 42
+	maxRand  = 10
+	gridSize = 200
+	numNeigh = 4
+)
+
+func main() {
+	// Generate test data.
+	rand.Seed(seed)
+	endX, endY := gridSize-1, gridSize-1
+	nodes := make([]*astar.Node, 0, gridSize*gridSize)
+	heuristic := astar.ConstantHeuristic{}
+
+	log.Println("iniitalising")
+
+	// Create nodes and compute constant heuristic.
+	for xIdx := 0; xIdx < gridSize; xIdx++ {
+		for yIdx := 0; yIdx < gridSize; yIdx++ {
+			node, err := astar.NewNode(
+				fmt.Sprintf("{%d,%d}", xIdx, yIdx), rand.Intn(maxRand), numNeigh, nil,
+			)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+			nodes = append(nodes, node)
+			heuristic.AddNode(node, (endX-xIdx)+(endY-yIdx))
+		}
+	}
+
+	log.Println("created nodes")
+
+	start := nodes[0]
+	end := nodes[len(nodes)-1]
+
+	// Add connections.
+	for idx, node := range nodes {
+		if idx >= gridSize {
+			up := nodes[idx-gridSize]
+			node.AddPairwiseConnection(up)
+		}
+		if idx+gridSize < len(nodes) {
+			down := nodes[idx+gridSize]
+			node.AddPairwiseConnection(down)
+		}
+		if idx%gridSize > 0 {
+			left := nodes[idx-1]
+			node.AddPairwiseConnection(left)
+		}
+		if idx%gridSize < gridSize-1 {
+			right := nodes[idx+1]
+			node.AddPairwiseConnection(right)
+		}
+	}
+
+	log.Println("connected nodes")
+
+	// Convert to graph.
+	graph := astar.Graph{}
+	for _, node := range nodes {
+		graph.Add(node)
+	}
+
+	log.Println("converted to graph")
+
+	startTime := time.Now()
+	// Run the test.
+	_, err := astar.FindPath(graph, start, end, heuristic.Heuristic(0))
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	duration := time.Since(startTime)
+
+	log.Println("obtained path")
+
+	fmt.Println(duration)
+}

--- a/tests/main.go
+++ b/tests/main.go
@@ -25,7 +25,7 @@ func main() {
 	nodes := make([]*astar.Node, 0, gridSize*gridSize)
 	heuristic := astar.ConstantHeuristic{}
 
-	log.Println("iniitalising")
+	log.Println("inititalising")
 
 	// Create nodes and compute constant heuristic.
 	for xIdx := 0; xIdx < gridSize; xIdx++ {

--- a/tests/main.go
+++ b/tests/main.go
@@ -85,7 +85,7 @@ func main() {
 	case "HEAPED":
 		graph = astar.NewHeapedGraph(gridSize * gridSize)
 	case "MAPPED":
-		graph = astar.NewGraph()
+		graph = astar.NewGraph(gridSize * gridSize)
 	default:
 		log.Fatal("Env var GRAPH_TYPE not set to a supported value.")
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -112,9 +112,11 @@ func main() {
 		cost += node.Cost
 	}
 
+	logStr(fmt.Sprintf("total cost is %d", cost))
+
 	if len(path) != expectedLength {
-		log.Fatal(
-			"path does not have the expected length (want: %d, has: %d",
+		log.Fatalf(
+			"path does not have the expected length (want: %d, has: %d)",
 			expectedLength, len(path),
 		)
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	seed     = 42
-	maxRand  = 10
-	gridSize = 200
-	numNeigh = 4
+	seed           = 42
+	maxRand        = 10
+	gridSize       = 200
+	numNeigh       = 4
+	expectedLength = 417
+	expectedCost   = 827
 )
 
 func main() {
@@ -78,11 +80,30 @@ func main() {
 
 	startTime := time.Now()
 	// Run the test.
-	_, err := astar.FindPath(graph, start, end, heuristic.Heuristic(0))
+	path, err := astar.FindPath(graph, start, end, heuristic.Heuristic(0))
 	if err != nil {
 		log.Fatal(err.Error())
 	}
 	duration := time.Since(startTime)
+
+	log.Println("path is")
+
+	cost := 0
+	for _, node := range path {
+		log.Println(node.ToString())
+		cost += node.Cost
+	}
+
+	if len(path) != expectedLength {
+		log.Fatal(
+			"path does not have the expected length (want: %d, has: %d",
+			expectedLength, len(path),
+		)
+	}
+
+	if cost != expectedCost {
+		log.Fatalf("path does not have the expected cost (want: %d, has: %d)", expectedCost, cost)
+	}
 
 	log.Println("obtained path")
 

--- a/tests/main.go
+++ b/tests/main.go
@@ -71,7 +71,7 @@ func main() {
 	log.Println("connected nodes")
 
 	// Convert to graph.
-	graph := astar.Graph{}
+	graph := astar.NewGraph()
 	for _, node := range nodes {
 		graph.Add(node)
 	}
@@ -80,7 +80,7 @@ func main() {
 
 	startTime := time.Now()
 	// Run the test.
-	path, err := astar.FindPath(&graph, start, end, heuristic.Heuristic(0))
+	path, err := astar.FindPath(graph, start, end, heuristic.Heuristic(0))
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -80,7 +80,7 @@ func main() {
 
 	startTime := time.Now()
 	// Run the test.
-	path, err := astar.FindPath(graph, start, end, heuristic.Heuristic(0))
+	path, err := astar.FindPath(&graph, start, end, heuristic.Heuristic(0))
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/razziel89/astar"
@@ -20,6 +21,14 @@ const (
 	expectedCost   = 827
 )
 
+var quiet = os.Getenv("QUIET") == "1"
+
+func logStr(str string) {
+	if !quiet {
+		log.Print(str)
+	}
+}
+
 func main() {
 	// Generate test data.
 	rand.Seed(seed)
@@ -27,7 +36,7 @@ func main() {
 	nodes := make([]*astar.Node, 0, gridSize*gridSize)
 	heuristic := astar.ConstantHeuristic{}
 
-	log.Println("inititalising")
+	logStr("inititalising")
 
 	// Create nodes and compute constant heuristic.
 	for xIdx := 0; xIdx < gridSize; xIdx++ {
@@ -43,7 +52,7 @@ func main() {
 		}
 	}
 
-	log.Println("created nodes")
+	logStr("created nodes")
 
 	start := nodes[0]
 	end := nodes[len(nodes)-1]
@@ -68,15 +77,24 @@ func main() {
 		}
 	}
 
-	log.Println("connected nodes")
+	logStr("connected nodes")
 
 	// Convert to graph.
-	graph := astar.NewGraph()
+	var graph astar.GraphOps
+	switch os.Getenv("GRAPH_TYPE") {
+	case "HEAPED":
+		graph = astar.NewHeapedGraph(gridSize * gridSize)
+	case "MAPPED":
+		graph = astar.NewGraph()
+	default:
+		log.Fatal("Env var GRAPH_TYPE not set to a supported value.")
+	}
+
 	for _, node := range nodes {
 		graph.Add(node)
 	}
 
-	log.Println("converted to graph")
+	logStr("converted to graph")
 
 	startTime := time.Now()
 	// Run the test.
@@ -86,11 +104,11 @@ func main() {
 	}
 	duration := time.Since(startTime)
 
-	log.Println("path is")
+	logStr("path is")
 
 	cost := 0
 	for _, node := range path {
-		log.Println(node.ToString())
+		logStr(node.ToString())
 		cost += node.Cost
 	}
 
@@ -105,7 +123,7 @@ func main() {
 		log.Fatalf("path does not have the expected cost (want: %d, has: %d)", expectedCost, cost)
 	}
 
-	log.Println("obtained path")
+	logStr("obtained path")
 
 	fmt.Println(duration)
 }


### PR DESCRIPTION
A heap is faster for every operation apart from existence checks.

Fixes #1.

A few changes were needed:
- Evaluation of heuristic during node addition to graph instead of when retrieving the cheapest.
  - The estimate for a node can now no longer be updated after it has been added, but constant heuristics are the most common ones anyway.
- Addition of a large performance test that operates as a client to the package.
- Addition of make targets.
- Addition of a preliminary heap structure based on a slice (untested).

Turns out I have been using the heap structure wrong. Some more tests are needed. The heap did not actually do any sorting so far.